### PR TITLE
service preemption on StateMachine

### DIFF
--- a/smach/src/smach/state_machine.py
+++ b/smach/src/smach/state_machine.py
@@ -371,6 +371,9 @@ class StateMachine(smach.container.Container):
             # We're no longer running
             self._is_running = False
 
+            if self._preempt_requested:
+                self.service_preempt()
+
         return container_outcome
 
     ## Preemption management


### PR DESCRIPTION
If we are leaving StateMachine execution and preemption was not served, just do it.
fixes https://github.com/mojin-robotics/mojin_behaviors/issues/66 
fixes https://github.com/mojin-robotics/mojin_behaviors/issues/60
