### PR TITLE
Feature/concurrent exceptions

### DIFF
--- a/smach/src/smach/concurrence.py
+++ b/smach/src/smach/concurrence.py
@@ -338,9 +338,9 @@ class Concurrence(smach.container.Container):
                 self._states[label].get_registered_input_keys(),
                 self._states[label].get_registered_output_keys(),
                 self._remappings[label]))
-        except:
+        except Exception, e:
             self._user_code_exception = True
-            self._child_exceptions[label] = traceback.format_exc()
+            self._child_exceptions[label] = e
             with self._done_cond:
                 self._done_cond.notify_all()
             raise smach.InvalidStateError(("Could not execute child state '%s': " % label)+traceback.format_exc())


### PR DESCRIPTION
I used https://gist.github.com/LoyVanBeek/7154a025d1c7fbb43e530319a6c8c59b for testing.

The output on an exception is:
```python
[  INFO ] : Concurrence starting with userdata: 
	[]
[  INFO ] : Concurrent state 'BAR' returned outcome 'outcome2' on termination.
[ ERROR ] : InvalidStateError: Could not execute child state 'FOO': Traceback (most recent call last):
  File "/home/lvb/git/mojin_ws/src/executive_smach/smach/src/smach/concurrence.py", line 340, in _state_runner
    self._remappings[label]))
  File "use_concurrence.py", line 10, in execute
    assert False, "Just some exception"
AssertionError: Just some exception

[ DEBUG ] : SMACH Concurrence preempting running states.
Exception in thread concurrent_split:FOO:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/lvb/git/mojin_ws/src/executive_smach/smach/src/smach/concurrence.py", line 346, in _state_runner
    raise smach.InvalidStateError(("Could not execute child state '%s': " % label)+traceback.format_exc())
InvalidStateError: Could not execute child state 'FOO': Traceback (most recent call last):
  File "/home/lvb/git/mojin_ws/src/executive_smach/smach/src/smach/concurrence.py", line 340, in _state_runner
    self._remappings[label]))
  File "use_concurrence.py", line 10, in execute
    assert False, "Just some exception"
AssertionError: Just some exception


[ ERROR ] : InvalidStateError: A concurrent state raised an exception during execution: {'FOO': AssertionError('Just some exception',)}
A concurrent state raised an exception during execution: {'FOO': AssertionError('Just some exception',)}
```
